### PR TITLE
Change Text PropTypes from 'string' to 'node'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Confirm Dialog for react with Bootstrap Modal.
 #### body: React.PropTypes.any.isRequired
 Body text for the modal.
 
-#### buttonText: React.PropTypes.string
+#### buttonText: React.PropTypes.any
 Options text for the initial button.  Is only used if children are not passed.
 
-#### cancelText: React.PropTypes.string
+#### cancelText: React.PropTypes.any
 Text for the cancel button in the modal.
 
-#### confirmText: React.PropTypes.string
+#### confirmText: React.PropTypes.any
 Text for the confirm button in the modal.
 
 #### onConfirm: React.PropTypes.func.isRequired

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# react-bootstrap-confirm
+# react-confirm-bootstrap
 Confirm Dialog for react with Bootstrap Modal.
 
 

--- a/src/Confirm.js
+++ b/src/Confirm.js
@@ -4,9 +4,9 @@ var { Button, Modal } = require('react-bootstrap');
 var Confirm = React.createClass({
     propTypes: {
         body: React.PropTypes.any.isRequired,
-        buttonText: React.PropTypes.string,
-        cancelText: React.PropTypes.string,
-        confirmText: React.PropTypes.string,
+        buttonText: React.PropTypes.any,
+        cancelText: React.PropTypes.any,
+        confirmText: React.PropTypes.any,
         onConfirm: React.PropTypes.func.isRequired,
         title: React.PropTypes.string.isRequired,
         visible: React.PropTypes.bool,

--- a/src/Confirm.js
+++ b/src/Confirm.js
@@ -3,12 +3,12 @@ var { Button, Modal } = require('react-bootstrap');
 
 var Confirm = React.createClass({
     propTypes: {
-        body: React.PropTypes.any.isRequired,
-        buttonText: React.PropTypes.any,
-        cancelText: React.PropTypes.any,
-        confirmText: React.PropTypes.any,
+        body: React.PropTypes.node.isRequired,
+        buttonText: React.PropTypes.node,
+        cancelText: React.PropTypes.node,
+        confirmText: React.PropTypes.node,
         onConfirm: React.PropTypes.func.isRequired,
-        title: React.PropTypes.string.isRequired,
+        title: React.PropTypes.node.isRequired,
         visible: React.PropTypes.bool,
     },
 


### PR DESCRIPTION
I'm using an i18n plugin which creates a component for the created strings, your plugin will give me an error if I try to specify components as properties. I also fixed a typo in the title.