### PR TITLE
bugfix on last PR - cancel button cannot be displayed

### DIFF
--- a/src/Confirm.js
+++ b/src/Confirm.js
@@ -55,7 +55,7 @@ var Confirm = React.createClass({
     },
 
     render() {
-        var cancelButton = this.state.showCancelButton ?
+        var cancelButton = this.props.showCancelButton ?
             (<Button bsStyle="default" onClick={this.onClose}>{this.props.cancelText}</Button>) : null;
         var modal = (
             <Modal show={this.state.isOpened} onHide={this.onClose}>

--- a/src/Confirm.js
+++ b/src/Confirm.js
@@ -5,6 +5,7 @@ var Confirm = React.createClass({
     propTypes: {
         body: React.PropTypes.node.isRequired,
         buttonText: React.PropTypes.node,
+        showCancelButton: React.PropTypes.bool.isRequired,
         cancelText: React.PropTypes.node,
         confirmBSStyle: React.PropTypes.string,
         confirmText: React.PropTypes.node,
@@ -16,6 +17,7 @@ var Confirm = React.createClass({
     getDefaultProps() {
         return {
             cancelText: 'Cancel',
+            showCancelButton: true,
             confirmText: 'Confirm',
             confirmBSStyle: 'danger',
         };
@@ -53,6 +55,8 @@ var Confirm = React.createClass({
     },
 
     render() {
+        var cancelButton = this.state.showCancelButton ?
+            (<Button bsStyle="default" onClick={this.onClose}>{this.props.cancelText}</Button>) : null;
         var modal = (
             <Modal show={this.state.isOpened} onHide={this.onClose}>
                 <Modal.Header>
@@ -62,7 +66,7 @@ var Confirm = React.createClass({
                     {this.props.body}
                 </Modal.Body>
                 <Modal.Footer>
-                    <Button bsStyle="default" onClick={this.onClose}>{this.props.cancelText}</Button>
+                    {cancelButton}
                     <Button bsStyle={this.props.confirmBSStyle} onClick={this.onConfim}>{this.props.confirmText}</Button>
                 </Modal.Footer>
             </Modal>

--- a/src/Confirm.js
+++ b/src/Confirm.js
@@ -5,11 +5,11 @@ var Confirm = React.createClass({
     propTypes: {
         body: React.PropTypes.node.isRequired,
         buttonText: React.PropTypes.node,
-        showCancelButton: React.PropTypes.bool.isRequired,
         cancelText: React.PropTypes.node,
         confirmBSStyle: React.PropTypes.string,
         confirmText: React.PropTypes.node,
         onConfirm: React.PropTypes.func.isRequired,
+        showCancelButton: React.PropTypes.bool.isRequired,
         title: React.PropTypes.node.isRequired,
         visible: React.PropTypes.bool,
     },
@@ -17,9 +17,9 @@ var Confirm = React.createClass({
     getDefaultProps() {
         return {
             cancelText: 'Cancel',
-            showCancelButton: true,
             confirmText: 'Confirm',
             confirmBSStyle: 'danger',
+            showCancelButton: true,
         };
     },
 


### PR DESCRIPTION
I'm sorry, seems like I made mistake when used `state`. In that way cancel button don't show at all...