### PR TITLE
Change import style to greatly reduce size

### DIFF
--- a/src/Confirm.js
+++ b/src/Confirm.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Button, Modal } from 'react-bootstrap';
+import Button from 'react-bootstrap/lib/Button';
+import Modal from 'react-bootstrap/lib/Modal';
 
 class Confirm extends React.Component {
 


### PR DESCRIPTION
I'd been trying to reduce my Webpack bundle, but this otherwise awesome component was insisting on pulling in all of react-bootstrap.

With this change, only the needed react-bootstrap components will be loaded.
Please consider merging! :)

Reference:
https://stackoverflow.com/questions/34239731/how-to-minimize-the-size-of-webpacks-bundle#34241128