### PR TITLE
Add on close prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Default: 'danger'
 #### confirmText: React.PropTypes.node
 Text for the confirm button in the modal.
 
+#### onClose: React.PropTypes.func
+Function to be called once closed.
+
 #### onConfirm: React.PropTypes.func.isRequired
 Function to be called once confirmed.
 

--- a/src/Confirm.js
+++ b/src/Confirm.js
@@ -25,6 +25,10 @@ class Confirm extends React.Component {
         this.setState({
             isOpened: false
         });
+
+        if (typeof this.props.onClose == 'function') {
+            this.props.onClose();
+        }
     }
 
     onConfirm(event) {
@@ -86,6 +90,7 @@ Confirm.propTypes = {
     confirmBSStyle: PropTypes.string,
     confirmText: PropTypes.node,
     onConfirm: PropTypes.func.isRequired,
+    onClose: PropTypes.func,
     showCancelButton: PropTypes.bool.isRequired,
     title: PropTypes.node.isRequired,
     visible: PropTypes.bool

--- a/src/Confirm.test.js
+++ b/src/Confirm.test.js
@@ -1,0 +1,126 @@
+import React from 'react';
+import ReactTestUtils from 'react-dom/test-utils';
+import Confirm from './Confirm';
+
+it('renders properly without onClose prop', () => {
+    let component = ReactTestUtils.renderIntoDocument(
+        <Confirm
+            onConfirm={() => {}}
+            body="Are you sure?"
+            confirmText="Confirm"
+            title="Confirmation">
+            <button className="btn">Action</button>
+        </Confirm>
+    )
+
+    // no modal dialog yet
+    expect(
+        ReactTestUtils.scryRenderedDOMComponentsWithClass(component, 'modal-dialog')
+    ).toEqual([]);
+
+    let actionButton = ReactTestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'btn'
+    );
+    expect(actionButton.nodeType).toEqual(Node.ELEMENT_NODE);
+    expect(actionButton.textContent).toMatch('Action');
+});
+
+it('renders properly with onClose prop', () => {
+    let component = ReactTestUtils.renderIntoDocument(
+        <Confirm
+            onConfirm={() => {}}
+            onClose={() => {}}
+            body="Are you sure?"
+            confirmText="Confirm"
+            title="Confirmation">
+            <button className="btn">Action</button>
+        </Confirm>
+    )
+
+    // no modal dialog yet
+    expect(
+        ReactTestUtils.scryRenderedDOMComponentsWithClass(component, 'modal-dialog')
+    ).toEqual([]);
+
+    let actionButton = ReactTestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'btn'
+    );
+    expect(actionButton.nodeType).toEqual(Node.ELEMENT_NODE);
+    expect(actionButton.textContent).toMatch('Action');
+});
+
+it('click on confirm calls onConfirm callback', (done) => {
+    var onConfirmCallback = function () {
+        console.log('Confimred!');
+        done();
+    };
+
+    let component = ReactTestUtils.renderIntoDocument(
+        <Confirm
+            onConfirm={() => {onConfirmCallback();}}
+            body="Are you sure?"
+            confirmText="Confirm"
+            confirmBSStyle="danger"
+            title="Confirmation">
+            <button className="btn">Action</button>
+        </Confirm>
+    )
+
+    let actionButton = ReactTestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'btn'
+    );
+    ReactTestUtils.Simulate.click(actionButton);
+
+    let confirmationDialog = ReactTestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'modal-dialog'
+    );
+    expect(confirmationDialog).toBeTruthy();
+    expect(confirmationDialog.nodeType).toEqual(Node.ELEMENT_NODE);
+
+    let confirmButton = ReactTestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'btn-danger'
+    );
+    expect(confirmButton).toBeTruthy();
+    expect(confirmButton.nodeType).toEqual(Node.ELEMENT_NODE);
+
+    ReactTestUtils.Simulate.click(confirmButton);
+});
+
+it('click on cancel calls onClose callback prop', (done) => {
+    var onCloseCallback = function () {
+        console.log('Closed!');
+        done();
+    };
+
+    let component = ReactTestUtils.renderIntoDocument(
+        <Confirm
+            onConfirm={() => {console.log('Confirmed');}}
+            onClose={() => {onCloseCallback();}}
+            body="Are you sure?"
+            confirmText="Confirm"
+            confirmBSStyle="danger"
+            title="Confirmation">
+            <button className="btn">Action</button>
+        </Confirm>
+    )
+
+    let actionButton = ReactTestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'btn'
+    );
+    ReactTestUtils.Simulate.click(actionButton);
+
+    let cancelButton = ReactTestUtils.findRenderedDOMComponentWithClass(
+        component,
+        'btn-default'
+    );
+    expect(cancelButton).toBeTruthy();
+    expect(cancelButton.nodeType).toEqual(Node.ELEMENT_NODE);
+
+    ReactTestUtils.Simulate.click(cancelButton);
+});


### PR DESCRIPTION
Add `onClose` prop callback, with more tests for Confirm component, so users can hook callback to be notified when the confirmation is closed (canceled).
